### PR TITLE
Use an exception to cancle user interactions

### DIFF
--- a/khard/config.py
+++ b/khard/config.py
@@ -1,6 +1,7 @@
 """Loading and validation of the configuration file"""
 
 from argparse import Namespace
+import io
 import locale
 import logging
 import os
@@ -22,6 +23,10 @@ from .query import Query
 
 
 logger = logging.getLogger(__name__)
+# This is the type of the config file parameter accepted by the configobj
+# library:
+# https://configobj.readthedocs.io/en/latest/configobj.html#reading-a-config-file
+ConfigFile = Union[str, List[str], io.StringIO]
 
 
 class ConfigError(Exception):
@@ -88,7 +93,7 @@ class Config:
 
     supported_vcard_versions = ("3.0", "4.0")
 
-    def __init__(self, config_file: Optional[str] = None) -> None:
+    def __init__(self, config_file: Optional[ConfigFile] = None) -> None:
         self.config: configobj.ConfigObj
         self.abooks: AddressBookCollection
         locale.setlocale(locale.LC_ALL, '')
@@ -97,7 +102,7 @@ class Config:
         self._set_attributes()
 
     @classmethod
-    def _load_config_file(cls, config_file: Optional[str]
+    def _load_config_file(cls, config_file: Optional[ConfigFile]
                           ) -> configobj.ConfigObj:
         """Find and load the config file.
 

--- a/khard/helpers/interactive.py
+++ b/khard/helpers/interactive.py
@@ -15,6 +15,10 @@ from ..carddav_object import CarddavObject
 T = TypeVar("T")
 
 
+class Canceled(Exception):
+    pass
+
+
 def confirm(message: str, accept_enter_key: bool = True) -> bool:
     """Ask the user for confirmation on the terminal.
 
@@ -43,15 +47,16 @@ def select(items: Sequence[T], include_none: bool = False) -> Optional[T]:
     :param items: the list from which to select
     :param include_none: whether to allow the selection of no item
     :returns: None or the selected item
+    :raises Canceled: when the user canceled the selection process
     """
+    prompt = "Enter Index ({}q to quit): ".format("0 for None, "
+                                                  if include_none else "")
     while True:
         try:
-            answer = input("Enter Index ({}q to quit): ".format(
-                "0 for None, " if include_none else ""))
+            answer = input(prompt)
             answer = answer.lower()
-            if answer in ["", "q"]:
-                print("Canceled")
-                return None
+            if answer == "q":
+                raise Canceled()
             index = int(answer)
             if include_none and index == 0:
                 return None

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -21,7 +21,7 @@ from ruamel.yaml import YAML
 
 from khard import cli
 from khard import config
-from khard.helpers.interactive import EditState, Editor
+from khard.helpers.interactive import Editor
 from khard import khard
 
 from .helpers import TmpConfig, mock_stream
@@ -39,8 +39,8 @@ class HelpOption(unittest.TestCase):
 
     def _test(self, args, expect):
         """Test the command line args and compare the prefix of the output."""
-        with self.assertRaises(SystemExit):
-            with mock_stream() as stdout:
+        with mock_stream() as stdout:
+            with self.assertRaises(SystemExit):
                 cli.parse_args(args)
         text = stdout.getvalue()
         self.assertRegex(text, expect)
@@ -165,8 +165,8 @@ class ListingCommands(unittest.TestCase):
         self.assertListEqual(text2, expected)
 
     def test_regex_special_chars_are_not_special(self):
-        with self.assertRaises(SystemExit):
-            with mock_stream() as stdout:
+        with mock_stream() as stdout:
+            with self.assertRaises(SystemExit):
                 khard.main(['list', 'uid.'])
         self.assertEqual(stdout.getvalue(), "Found no contacts\n")
 

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -502,9 +502,6 @@ class Merge(unittest.TestCase):
 
 class AddEmail(unittest.TestCase):
 
-    # FIXME the new code from fdc441cf asks for confirmation in
-    # khard.add_email_to_contact on line 419
-    @unittest.skip("unexpected read from stdin blocks the test")
     @TmpConfig(["contact1.vcf", "contact2.vcf"])
     def test_contact_is_found_if_name_matches(self):
         email = [
@@ -516,12 +513,12 @@ class AddEmail(unittest.TestCase):
         with tempfile.NamedTemporaryFile("w") as tmp:
             tmp.writelines(email)
             tmp.flush()
-            with mock.patch("khard.khard.confirm", lambda x: True):
-                with mock.patch("builtins.input", lambda x: ""):
+            with mock.patch("khard.khard.confirm", lambda _: True):
+                with mock.patch("builtins.input", mock.Mock(
+                        side_effect=["y", ""])):
                     run_main("add-email", "--input-file", tmp.name)
-        stdout = run_main("list", "--fields=emails.internet.0")
-        addr = stdout.getvalue().splitlines()[-1].strip()
-        self.assertEqual(addr, "third@example.com")
+        emails = khard.config.abooks.get_short_uid_dict()["testuid2"].emails
+        self.assertEqual(emails["internet"][0], "third@example.com")
 
 
 if __name__ == "__main__":

--- a/test/test_helpers_interactive.py
+++ b/test/test_helpers_interactive.py
@@ -54,15 +54,14 @@ class Select(unittest.TestCase):
             actual = self._test(True)
         self.assertIsNone(actual)
 
-    def test_empty_input_cancels(self):
-        with mock.patch("builtins.input", lambda _: ""):
+    def test_empty_input_prints_a_message_and_repeats(self):
+        with mock.patch("builtins.input", mock.Mock(side_effect=["", "2"])):
             with mock_stream() as stdout:
                 actual = self._test()
         stdout = stdout.getvalue()
-        self.assertEqual(stdout, "Canceled\n")
-        self.assertIsNone(actual)
-
-
+        self.assertEqual(stdout, "Please enter an index value between 1 and 3 "
+                         "or q to quit.\n")
+        self.assertEqual(actual, "b")
 
 
 class Confirm(unittest.TestCase):

--- a/test/test_khard.py
+++ b/test/test_khard.py
@@ -49,7 +49,7 @@ class TestSearchQueryPreparation(unittest.TestCase):
         self.assertEqual(expected, prepared["foo"])
 
 
-class TestAddEmail(unittest.TestCase):
+class TestFindEmailAddress(unittest.TestCase):
 
     def test_find_email_addresses_empty_text_finds_none(self):
         text = ""


### PR DESCRIPTION
Previously None was used as a return value to indicate that the user canceled but since None is also used to indicate the user made "no selection" these were not distinguishable any longer.

Before 9d02824d "q" was handled by calling sys.exit directly.


@jeffa5 the commit 9d02824d was from you. I know this is a very long time ago, but do you remember why you replaced `sys.exit` with `return None` in the `select()` function?
https://github.com/lucc/khard/commit/9d02824d418b10ae817350dca442d5bd294b4130#diff-a61de8c4a830ae55b3d7cf5f20bf54f44b71f5684bd73e42094a83246c9fc820L600-R609

To me it looks like a "substitute all" mistake when replacing `sys.exit` in these places in the same commit:
https://github.com/lucc/khard/commit/9d02824d418b10ae817350dca442d5bd294b4130#diff-a61de8c4a830ae55b3d7cf5f20bf54f44b71f5684bd73e42094a83246c9fc820L565-R574
https://github.com/lucc/khard/commit/9d02824d418b10ae817350dca442d5bd294b4130#diff-a61de8c4a830ae55b3d7cf5f20bf54f44b71f5684bd73e42094a83246c9fc820L594-R603
https://github.com/lucc/khard/commit/9d02824d418b10ae817350dca442d5bd294b4130#diff-a61de8c4a830ae55b3d7cf5f20bf54f44b71f5684bd73e42094a83246c9fc820L600-R609

The commit ffbe09d reverts this and throws a custom exception if the user selects "quit". Is there any particular usage scenario where this is not acceptable?
I have tried to add more tests for the `add-email` subcomand but could not find such a use case.