### PR TITLE
Avoid circular imports

### DIFF
--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -16,19 +16,21 @@ import re
 import sys
 import time
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, \
-    TypeVar, Union, Sequence, overload
+    TYPE_CHECKING, TypeVar, Union, Sequence, overload
 
 from atomicwrites import atomic_write
 from ruamel import yaml
 from ruamel.yaml import YAML
 import vobject
 
-from . import address_book  # pylint: disable=unused-import # for type checking
 from . import helpers
 from .helpers.typing import (Date, ObjectType, PostAddress, StrList,
     convert_to_vcard, list_to_string, string_to_date,
     string_to_list)
 from .query import AnyQuery, Query
+
+if TYPE_CHECKING:
+    from . import address_book
 
 
 logger = logging.getLogger(__name__)

--- a/khard/query.py
+++ b/khard/query.py
@@ -5,9 +5,10 @@ from datetime import datetime
 from functools import reduce
 from operator import and_, or_
 import re
-from typing import cast, Any, Dict, List, Optional, Union
+from typing import cast, Any, Dict, List, Optional, TYPE_CHECKING, Union
 
-from . import carddav_object
+if TYPE_CHECKING:
+    from . import carddav_object
 
 # constants
 FIELD_PHONE_NUMBERS = "phone_numbers"
@@ -342,6 +343,8 @@ def parse(string: str) -> Union[TermQuery, FieldQuery]:
     :returns: a FieldQuery if the string contains a valid field specifier, a
         TermQuery otherwise
     """
+    from . import carddav_object
+
     if ":" in string:
         field, term = string.split(":", maxsplit=1)
         if field == "name":


### PR DESCRIPTION
https://bugs.debian.org/1069838 reported a test failure due to circular imports.  While I couldn't reproduce this locally, I could reproduce it in a VM provided by the bug reporter, and it seems straightforward enough to avoid the problem.