### PR TITLE
Add discover addressbook type

### DIFF
--- a/doc/source/examples/khard.conf.example
+++ b/doc/source/examples/khard.conf.example
@@ -8,6 +8,9 @@
 path = ~/.contacts/family/
 [[friends]]
 path = ~/.contacts/friends/
+[[work]]
+path = ~/.work/**/client-*-contacts/
+type = discover
 
 [general]
 debug = no

--- a/doc/source/man.rst
+++ b/doc/source/man.rst
@@ -8,4 +8,4 @@ The following man pages are available for khard:
 
    khard(1) <man/khard>
    khard-subcommands(1) <man/khard-subcommands>
-   khard.conf(1) <man/khard.conf>
+   khard.conf(5) <man/khard.conf>

--- a/doc/source/man/khard.conf.rst
+++ b/doc/source/man/khard.conf.rst
@@ -41,8 +41,10 @@ addressbooks
   This section contains several subsections, but at least one. Each subsection
   can have an arbitrary name which will be the name of an addressbook known to
   khard.  Each of these subsections **must** have a *path* key with the path to
-  the folder containing the vCard files for that addressbook.  The *path* value
-  supports environment variables and tilde prefixes.  :program:`khard` expects
+  the folder containing the vCard files for that addressbook. Optionally, you
+  can set the *type* value to either ``discover`` or ``vdir``, the default. The
+  *path* value supports environment variables and tilde prefixes. When using
+  the ``discover`` type, it also supports globbing. :program:`khard` expects
   the vCard files to hold only one VCARD record each and end in a :file:`.vcf`
   extension.
 

--- a/khard/config.py
+++ b/khard/config.py
@@ -142,6 +142,15 @@ class Config:
 
     @classmethod
     def _unfold_discover_books(cls, addressbooks: configobj.Section) -> configobj.Section:
+        """Expand globs in path of addressbooks of type "discover"
+
+        This expands all addressbooks of type "discover" into (potentially)
+        multiple addressbooks of type "vdir". The names are automatically generated
+        based on the directory name.
+
+        :param config: the configuration to be changed
+        :returns: the changed configuration with no "discover" addressbooks
+        """
         for section_name, book in addressbooks.copy().items():
             if book["type"] != "discover":
                 continue
@@ -166,6 +175,14 @@ class Config:
 
     @staticmethod
     def _find_leaf_dirs(hits: Iterable[str]) -> set[str]:
+        """Find leaf directories in a tree of hits when using glob.iglob
+
+        The hits are neither guaranteed to be unique nor leaf directories, both
+        of which are enforced by this function.
+
+        :param hits: the hits of a glob as returned by glob.iglob
+        :returns: a set of path strings
+        """
         dirs = {os.path.normpath(hit) for hit in hits if os.path.isdir(hit)}
         parents = {os.path.normpath(os.path.join(dir, os.pardir)) for dir in dirs}
         return dirs - parents

--- a/khard/config.py
+++ b/khard/config.py
@@ -8,6 +8,7 @@ import os
 import re
 import shlex
 from typing import Iterable, Optional, Union
+from glob import iglob
 
 import configobj
 try:
@@ -94,7 +95,9 @@ class Config:
         self.abooks: AddressBookCollection
         locale.setlocale(locale.LC_ALL, '')
         config = self._load_config_file(config_file)
-        self.config = self._validate(config)
+        config = self._validate(config)
+        config["addressbooks"] = self._unfold_discover_books(config["addressbooks"])
+        self.config = config
         self._set_attributes()
 
     @classmethod
@@ -136,6 +139,36 @@ class Config:
         if result:
             raise ConfigError
         return config
+
+    @classmethod
+    def _unfold_discover_books(cls, addressbooks: configobj.Section) -> configobj.Section:
+        for section_name, book in addressbooks.copy().items():
+            if book["type"] != "discover":
+                continue
+            hits = iglob(os.path.expanduser(book["path"]), recursive=True)
+            dirs = cls._find_leaf_dirs(hits)
+            for bookpath in dirs:
+                bookname = os.path.basename(bookpath)
+                # Make sure our name is unique
+                counter = 0
+                while bookname in addressbooks:
+                    counter += 1
+                    if bookname + f"-{counter}" in addressbooks:
+                        continue
+                    bookname += f"-{counter}"
+                    break
+                addressbooks[bookname] = {
+                    "type": "vdir",
+                    "path": bookpath,
+                }
+            addressbooks.pop(section_name)
+        return addressbooks
+
+    @staticmethod
+    def _find_leaf_dirs(hits: Iterable[str]) -> set[str]:
+        dirs = {os.path.normpath(hit) for hit in hits if os.path.isdir(hit)}
+        parents = {os.path.normpath(os.path.join(dir, os.pardir)) for dir in dirs}
+        return dirs - parents
 
     def _set_attributes(self) -> None:
         """Set the attributes from the internal config instance on self."""

--- a/khard/data/config.spec
+++ b/khard/data/config.spec
@@ -25,3 +25,4 @@ skip_unparsable = boolean(default=False)
 [addressbooks]
   [[__many__]]
     path = string
+    type = option('vdir', 'discover', default='vdir')

--- a/test/fixture/discover.conf
+++ b/test/fixture/discover.conf
@@ -1,0 +1,4 @@
+[addressbooks]
+[[discovered]]
+path = test/fixture/*.abook
+type = discover

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -50,6 +50,13 @@ class LoadingConfigFile(unittest.TestCase):
                 with self.assertRaises(ConfigError):
                     config.Config(name)
 
+    def test_discover_books(self):
+        filename = "test/fixture/discover.conf"
+        cfg = config.Config(filename)
+        cfg.init_address_books()
+        expected = {'broken.abook', 'nick.abook', 'test.abook', 'minimal.abook'}
+        self.assertEqual(set(cfg.abooks._abooks.keys()), expected)
+
     @mock.patch.dict("os.environ", EDITOR="editor", MERGE_EDITOR="meditor")
     def test_load_minimal_file_by_name(self):
         cfg = config.Config("test/fixture/minimal.conf")


### PR DESCRIPTION
As mentioned in #203 I took a shot at allowing globbing. The way this works is pretty similar to khal, essentially if you set the type option of an addressbook to `discover`, the path is run through `glob.glob` with `recursive = True`, and a separate addressbook is added for every folder that is found.

The first commit fixes a small typo, if preferred, I can also open a separate PR for that.