### PR TITLE
FIX: Special handling for ambiguous date formats

### DIFF
--- a/khard/contacts.py
+++ b/khard/contacts.py
@@ -33,7 +33,7 @@ from khard.exceptions import Cancelled
 from . import address_book  # pylint: disable=unused-import # for type checking
 from . import helpers
 from .helpers.typing import (Date, PostAddress, StrList, convert_to_vcard,
-    list_to_string, string_to_date, string_to_list)
+    list_to_string, string_to_date, string_to_list, DEFAULT_YEAR)
 from .query import AnyQuery, Query
 
 
@@ -450,7 +450,7 @@ class VCardWrapper:
                 return date.strip(), True
             return None, False
         tz = date.tzname()
-        if date.year == 1900 and date.month != 0 and date.day != 0 \
+        if date.year == DEFAULT_YEAR and date.month != 0 and date.day != 0 \
                 and date.hour == 0 and date.minute == 0 and date.second == 0 \
                 and self.version == "4.0":
             fmt = '--%m%d'
@@ -977,7 +977,7 @@ class YAMLEditable(VCardWrapper):
             return ""
         if isinstance(date, str):
             return date
-        if date.year == 1900 and date.month != 0 and date.day != 0 \
+        if date.year == DEFAULT_YEAR and date.month != 0 and date.day != 0 \
                 and date.hour == 0 and date.minute == 0 and date.second == 0:
             return date.strftime("--%m-%d")
         tz = date.tzname()
@@ -1075,8 +1075,8 @@ class YAMLEditable(VCardWrapper):
                              "with vcard version 4.0.")
         if re.match(r"^--\d\d-?\d\d$", new) and self.version != "4.0":
             raise ValueError(
-                f"{key} format --mm-dd and --mmdd only usable with "
-                "vcard version 4.0. You may use 1900 as placeholder, if "
+                f"{key} format --mm-dd and --mmdd only usable with vcard "
+                f"version 4.0. You may use {DEFAULT_YEAR} as placeholder, if "
                 "the year is unknown.")
         try:
             v2 = string_to_date(new)

--- a/khard/helpers/__init__.py
+++ b/khard/helpers/__init__.py
@@ -7,7 +7,7 @@ import string
 from typing import Any, Optional, Sequence, Union
 
 from ruamel.yaml.scalarstring import LiteralScalarString
-from .typing import list_to_string, PostAddress
+from .typing import list_to_string, PostAddress, DEFAULT_YEAR
 
 
 YamlPostAddresses = dict[str, Union[list[dict[str, Any]], dict[str, Any]]]
@@ -164,7 +164,7 @@ def yaml_anniversary(anniversary: Union[str, datetime, None],
         return None
 
     if isinstance(anniversary, datetime):
-        if (version == "4.0" and anniversary.year == 1900
+        if (version == "4.0" and anniversary.year == DEFAULT_YEAR
                              and anniversary.month != 0
                              and anniversary.day != 0
                              and anniversary.hour == 0

--- a/khard/helpers/typing.py
+++ b/khard/helpers/typing.py
@@ -10,6 +10,14 @@ StrList = Union[str, list[str]]
 PostAddress = dict[str, str]
 
 
+# A default year for datetimes without one.  Python does not support datetime
+# objects without a year from 3.15 onwards but vCard does.  We add a default
+# year to the python object and detect it again when formatting the object.
+# 1900 was the internally used default year of python's datetime object when it
+# still did support instances without a year (before python 3.5).
+DEFAULT_YEAR = 1900
+
+
 @overload
 def convert_to_vcard(name: str, value: StrList, constraint: type[str]) -> str: ...
 @overload
@@ -77,10 +85,11 @@ def string_to_date(string: str) -> datetime:
     # Ambiguous cases of a date with no year (--%m%d and --%m-%d).
     try:
         if string.startswith("--"):
+            tmp = str(DEFAULT_YEAR) + string[2:]
             if "-" in string[2:]:
-                return datetime.strptime("1900-" + string[2:], "%Y-%m-%d")
+                return datetime.strptime(tmp, "%Y%m-%d")
             else:
-                return datetime.strptime("1900" + string[2:], "%Y%m%d")
+                return datetime.strptime(tmp, "%Y%m%d")
     except ValueError:
         pass
 
@@ -107,4 +116,3 @@ def string_to_date(string: str) -> datetime:
 
     # All formats tried. Date cannot be parsed.
     raise ValueError
-


### PR DESCRIPTION
This small patch revises the `string_to_date` function in `typing.py` to more gracefully handle parsing dates without a year. The motivation being to address the DeprecationWarning issued by Python in recent versions (and to avoid a possible breakage in the upcoming Python 3.15).

This closes #335 on the bug board.

* Interpolates the placeholder year 1900 for the two ambiguous formats.
* Formatted with `ruff`.

Before
```
................./home/troy/projects/khard/khard/helpers/typing.py:76: DeprecationWarning: Parsing dates i
nvolving a day of month without a year specified is ambiguous
and fails to parse leap day. The default behavior will change in Python 3.15
to either always raise an exception or to use a different default year (TBD).
To avoid trouble, add a specific year to the input & format.
See https://github.com/python/cpython/issues/70647.
  return datetime.strptime(string, fmt)
.................../home/troy/projects/khard/khard/cli.py:208: PendingDeprecationWarning: FileType is depr
ecated. Simply open files after parsing arguments.
  type=argparse.FileType("w"),
..........................................................................................................
....................................................................................ss....................
.....................................................................x....................................
.............................................
----------------------------------------------------------------------
Ran 399 tests in 0.326s

OK (skipped=2, expected failures=1)
```

After
```
..................................../home/troy/projects/khard/khard/cli.py:208: PendingDeprecationWarning:
 FileType is deprecated. Simply open files after parsing arguments.
  type=argparse.FileType("w"),
..........................................................................................................
....................................................................................ss....................
.....................................................................x....................................
.............................................
----------------------------------------------------------------------
Ran 399 tests in 0.327s

OK (skipped=2, expected failures=1)
```

and

```
$ python -W error::DeprecationWarning -m unittest test.test_helpers_typing.StringToDate
..........
----------------------------------------------------------------------
Ran 10 tests in 0.003s

OK

```
